### PR TITLE
use postgres instead of postgres_psycopg2 which has been an alias sin…

### DIFF
--- a/django-postgreconnect/base.py
+++ b/django-postgreconnect/base.py
@@ -1,4 +1,4 @@
-from django.db.backends.postgresql_psycopg2.base import DatabaseWrapper as PostgresWrapper
+from django.db.backends.postgresql.base import DatabaseWrapper as PostgresWrapper
 
 
 class DatabaseWrapper(PostgresWrapper):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name="django-postgreconnect",
     packages=["django-postgreconnect",],
-    version="0.2",
+    version="0.3",
     description="A Django backend that automatically reconnects to postgres if the connection is lost.",
     author="Jared Mackey",
     author_email="jared@mackeydevelopments.com",


### PR DESCRIPTION
…ce django 1.9 and is now removed in django 3.0, which breaks this package

django < 1.9 is already out of support (since 2017 https://www.djangoproject.com/download/ )

Django 3.0 removed the alias : 
(https://docs.djangoproject.com/en/3.0/releases/3.0/)
_The django.db.backends.postgresql_psycopg2 module is removed._

This has been an alias anyway for years

https://docs.djangoproject.com/en/3.0/releases/2.0/#deprecated-features-2-0
_The django.db.backends.postgresql_psycopg2 module is deprecated in favor of django.db.backends.postgresql. It’s been an alias since Django 1.9. This only affects code that imports from the module directly. The DATABASES setting can still use 'django.db.backends.postgresql_psycopg2', though you can simplify that by using the 'django.db.backends.postgresql' name added in Django 1.9._

Could you also publish the new version to pypi ?

thanks
